### PR TITLE
Stories/367 turns on collaborative only

### DIFF
--- a/memoryexpt2/experiment.py
+++ b/memoryexpt2/experiment.py
@@ -41,11 +41,11 @@ class CoordinationChatroom(dlgr.experiments.Experiment):
         self.num_participants = 2 #55 #55 #140 below
         self.initial_recruitment_size = 2 #self.num_participants * 1 #note: can't do *2.5 here, won't run even if the end result is an integer
         self.quorum = self.num_participants  # quorum is read by waiting room
+        self.game = games.by_name(u'open', quorum=self.quorum)
+        self.enforce_turns = self.game.enforce_turns  # Configures front-end
         import models
         self.models = models
         self.known_classes["Fillerans"] = models.Fillerans
-        self.game = games.by_name(u'open', quorum=self.quorum)
-        self.enforce_turns = self.game.enforce_turns  # Configures front-end
         if session:
             self.setup()
 

--- a/memoryexpt2/experiment.py
+++ b/memoryexpt2/experiment.py
@@ -4,12 +4,12 @@ import json
 import logging
 import random
 import six
-import time
 
 import dallinger as dlgr
 from dallinger.heroku.worker import conn as redis
 from dallinger.models import Node
 from dallinger.nodes import Source
+from . import games
 
 
 logger = logging.getLogger(__file__)
@@ -29,185 +29,6 @@ def serve_game():
     )
 
 
-class Turn(object):
-
-    def __init__(self):
-        self.start = time.time()
-        self.timeout_secs = 5
-
-    @property
-    def is_expired(self):
-        age = time.time() - self.start
-        return age > self.timeout_secs
-
-
-class ExpiredTurn(object):
-
-    is_expired = True
-    timeout_secs = 0
-
-    def __init__(self):
-        pass
-
-
-class FixedRotation(object):
-    """Rotate through players in a fixed order."""
-
-    def __init__(self):
-        self._player_ids = []
-        self._active_player_idx = 0
-
-    def add(self, player_id):
-        if player_id not in self._player_ids:
-            self._player_ids.append(player_id)
-
-    def remove(self, player_id):
-        if player_id in self._player_ids:
-            self._player_ids.remove(player_id)
-
-    def next(self):
-        self._active_player_idx = (self._active_player_idx + 1) % self.count
-        return self.current
-
-    @property
-    def current(self):
-        return self._player_ids[self._active_player_idx]
-
-    @property
-    def count(self):
-        return len(self._player_ids)
-
-    def __repr__(self):
-        return "%s %r" % (self.__class__, self._player_ids)
-
-
-class RandomRotation(FixedRotation):
-    """Rotated through players in a random order, but don't repeat any
-    players until every player has been visited.
-    """
-    def __init__(self):
-        self._player_ids = []
-        self._active_player = None
-        self._had_a_turn = set()
-
-    def next(self):
-        all_players = set(self._player_ids)
-        still_to_play = all_players - self._had_a_turn
-        if not still_to_play:
-            logger.info("Resetting round...")
-            self._had_a_turn.clear()
-            still_to_play = all_players
-        if still_to_play:
-            self._active_player = random.sample(still_to_play, 1)[0]
-            self._had_a_turn.add(self._active_player)
-        return self.current
-
-    @property
-    def current(self):
-        return self._active_player
-
-
-class FixedSequenceTurnTakingGame(object):
-
-    enforce_turns = True
-    _rotation = FixedRotation
-
-    def __init__(self, quorum):
-        self.rotation = self._rotation()
-        self.quorum = quorum
-        self._turn = ExpiredTurn()
-
-    def add_player(self, player_id):
-        self.rotation.add(player_id)
-        logger.info("Player {} has connected.".format(player_id))
-        logger.info(self.rotation)
-
-    def remove_player(self, player_id):
-        was_players_turn = self.rotation.current == player_id
-        self.rotation.remove(player_id)
-        if was_players_turn:
-            self.end_turn()
-        logger.info('Player {} has disconnected.'.format(player_id))
-
-    def word_added(self):
-        self.end_turn()
-
-    def turn_skipped(self):
-        self.end_turn()
-
-    def end_turn(self):
-        self._turn = ExpiredTurn()
-
-    def new_turn(self):
-        self._turn = Turn()
-
-    @property
-    def turn_is_over(self):
-        return self._turn.is_expired
-
-    @property
-    def all_players_have_joined(self):
-        return self.rotation.count == self.quorum
-
-    @property
-    def is_ready(self):
-        return self.all_players_have_joined
-
-    def tick(self):
-        """Update play state and return any messages to be published"""
-        if self.turn_is_over:
-            self.new_turn()
-            return self.change_player()
-
-    def change_player(self):
-        next_player = self.rotation.next()
-        message = {
-            'type': 'change_of_turn',
-            'player_id': next_player,
-            'turn_seconds': self._turn.timeout_secs
-        }
-        return message
-
-
-class RandomSequenceTurnTakingGame(FixedSequenceTurnTakingGame):
-
-    _rotation = RandomRotation
-
-
-class OpenGame(object):
-    """Any player can submit a (valid) word at any time"""
-
-    enforce_turns = False
-
-    def __init__(self, quorum):
-        self.quorum = quorum
-        self._players = []
-
-    def add_player(self, player_id):
-        self._players.append(player_id)
-        logger.info("Player {} has connected.".format(player_id))
-        logger.info(self._players)
-
-    def remove_player(self, player_id):
-        self._players.remove(player_id)
-        logger.info('Player {} has disconnected.'.format(player_id))
-
-    def word_added(self):
-        pass
-
-    def turn_skipped(self):
-        pass
-
-    @property
-    def is_ready(self):
-        logger.info("players: {}, quorum: {}".format(len(self._players), self.quorum))
-        return len(self._players) == self.quorum
-
-    def tick(self):
-        """We don't care"""
-        pass
-
-
 class CoordinationChatroom(dlgr.experiments.Experiment):
     """Define the structure of the experiment."""
 
@@ -220,11 +41,10 @@ class CoordinationChatroom(dlgr.experiments.Experiment):
         self.num_participants = 2 #55 #55 #140 below
         self.initial_recruitment_size = 2 #self.num_participants * 1 #note: can't do *2.5 here, won't run even if the end result is an integer
         self.quorum = self.num_participants  # quorum is read by waiting room
-        self.game = RandomSequenceTurnTakingGame(quorum=self.quorum)
         import models
         self.models = models
         self.known_classes["Fillerans"] = models.Fillerans
-        self.game = OpenGame(quorum=self.quorum)
+        self.game = games.by_name(u'open', quorum=self.quorum)
         self.enforce_turns = self.game.enforce_turns  # Configures front-end
         if session:
             self.setup()

--- a/memoryexpt2/experiment.py
+++ b/memoryexpt2/experiment.py
@@ -23,10 +23,10 @@ extra_routes = flask.Blueprint(
 
 @extra_routes.route("/exp")
 def serve_game():
-    """Return the game stage."""
-    return flask.render_template(
-        "exp.html",
-    )
+    """Render the game as a Flask template, so we can include
+    interpolated values from the Experiment.
+    """
+    return flask.render_template("exp.html")
 
 
 class CoordinationChatroom(dlgr.experiments.Experiment):

--- a/memoryexpt2/games.py
+++ b/memoryexpt2/games.py
@@ -84,7 +84,7 @@ class RandomRotation(FixedRotation):
         return self._active_player
 
 
-class MemoryGame(object):
+class TurnType(object):
     """Abstract base class"""
 
     is_ready = True
@@ -108,9 +108,9 @@ class MemoryGame(object):
         pass
 
 
-class OpenGame(MemoryGame):
+class FreeFlowing(TurnType):
     """Any player can submit a (valid) word at any time"""
-    nickname = u'open'
+    nickname = u'free'
     enforce_turns = False
 
     def __init__(self, quorum):
@@ -141,9 +141,9 @@ class OpenGame(MemoryGame):
         pass
 
 
-class FixedSequenceTurnTakingGame(MemoryGame):
+class FixedSequenceTurns(TurnType):
 
-    nickname = u'fixed_order_turns'
+    nickname = u'fixed_turns'
     enforce_turns = True
     _rotation = FixedRotation
 
@@ -204,7 +204,7 @@ class FixedSequenceTurnTakingGame(MemoryGame):
         return message
 
 
-class RandomSequenceTurnTakingGame(FixedSequenceTurnTakingGame):
+class RandomSequenceTurns(FixedSequenceTurns):
 
     nickname = u'random_turns'
     _rotation = RandomRotation
@@ -218,7 +218,7 @@ def _descendent_classes(cls):
 
 
 BY_NAME = {}
-for cls in _descendent_classes(MemoryGame):
+for cls in _descendent_classes(TurnType):
     BY_NAME[cls.__name__] = BY_NAME[cls.nickname] = cls
 
 

--- a/memoryexpt2/games.py
+++ b/memoryexpt2/games.py
@@ -1,0 +1,233 @@
+import logging
+import random
+import time
+
+
+logger = logging.getLogger(__name__)
+
+
+class Turn(object):
+
+    def __init__(self):
+        self.start = time.time()
+        self.timeout_secs = 5
+
+    @property
+    def is_expired(self):
+        age = time.time() - self.start
+        return age > self.timeout_secs
+
+
+class ExpiredTurn(object):
+
+    is_expired = True
+    timeout_secs = 0
+
+    def __init__(self):
+        pass
+
+
+class FixedRotation(object):
+    """Rotate through players in a fixed order."""
+
+    def __init__(self):
+        self._player_ids = []
+        self._active_player_idx = 0
+
+    def add(self, player_id):
+        if player_id not in self._player_ids:
+            self._player_ids.append(player_id)
+
+    def remove(self, player_id):
+        if player_id in self._player_ids:
+            self._player_ids.remove(player_id)
+
+    def next(self):
+        self._active_player_idx = (self._active_player_idx + 1) % self.count
+        return self.current
+
+    @property
+    def current(self):
+        return self._player_ids[self._active_player_idx]
+
+    @property
+    def count(self):
+        return len(self._player_ids)
+
+    def __repr__(self):
+        return "%s %r" % (self.__class__, self._player_ids)
+
+
+class RandomRotation(FixedRotation):
+    """Rotated through players in a random order, but don't repeat any
+    players until every player has been visited.
+    """
+    def __init__(self):
+        self._player_ids = []
+        self._active_player = None
+        self._had_a_turn = set()
+
+    def next(self):
+        all_players = set(self._player_ids)
+        still_to_play = all_players - self._had_a_turn
+        if not still_to_play:
+            logger.info("Resetting round...")
+            self._had_a_turn.clear()
+            still_to_play = all_players
+        if still_to_play:
+            self._active_player = random.sample(still_to_play, 1)[0]
+            self._had_a_turn.add(self._active_player)
+        return self.current
+
+    @property
+    def current(self):
+        return self._active_player
+
+
+class MemoryGame(object):
+    """Abstract base class"""
+
+    is_ready = True
+
+    def __init__(self, quorum):
+        pass
+
+    def add_player(self, player_id):
+        pass
+
+    def remove_player(self, player_id):
+        pass
+
+    def word_added(self):
+        pass
+
+    def turn_skipped(self):
+        pass
+
+    def tick(self):
+        pass
+
+
+class OpenGame(MemoryGame):
+    """Any player can submit a (valid) word at any time"""
+    nickname = u'open'
+    enforce_turns = False
+
+    def __init__(self, quorum):
+        self.quorum = quorum
+        self._players = []
+
+    def add_player(self, player_id):
+        self._players.append(player_id)
+        logger.info("Player {} has connected.".format(player_id))
+        logger.info(self._players)
+
+    def remove_player(self, player_id):
+        self._players.remove(player_id)
+        logger.info('Player {} has disconnected.'.format(player_id))
+
+    def word_added(self):
+        pass
+
+    def turn_skipped(self):
+        pass
+
+    @property
+    def is_ready(self):
+        logger.info("players: {}, quorum: {}".format(len(self._players), self.quorum))
+        return len(self._players) == self.quorum
+
+    def tick(self):
+        """We don't care"""
+        pass
+
+
+class FixedSequenceTurnTakingGame(MemoryGame):
+
+    nickname = u'fixed_order_turns'
+    enforce_turns = True
+    _rotation = FixedRotation
+
+    def __init__(self, quorum):
+        self.rotation = self._rotation()
+        self.quorum = quorum
+        self._turn = ExpiredTurn()
+
+    def add_player(self, player_id):
+        self.rotation.add(player_id)
+        logger.info("Player {} has connected.".format(player_id))
+        logger.info(self.rotation)
+
+    def remove_player(self, player_id):
+        was_players_turn = self.rotation.current == player_id
+        self.rotation.remove(player_id)
+        if was_players_turn:
+            self.end_turn()
+        logger.info('Player {} has disconnected.'.format(player_id))
+
+    def word_added(self):
+        self.end_turn()
+
+    def turn_skipped(self):
+        self.end_turn()
+
+    def end_turn(self):
+        self._turn = ExpiredTurn()
+
+    def new_turn(self):
+        self._turn = Turn()
+
+    @property
+    def turn_is_over(self):
+        return self._turn.is_expired
+
+    @property
+    def all_players_have_joined(self):
+        return self.rotation.count == self.quorum
+
+    @property
+    def is_ready(self):
+        return self.all_players_have_joined
+
+    def tick(self):
+        """Update play state and return any messages to be published"""
+        if self.turn_is_over:
+            self.new_turn()
+            return self.change_player()
+
+    def change_player(self):
+        next_player = self.rotation.next()
+        message = {
+            'type': 'change_of_turn',
+            'player_id': next_player,
+            'turn_seconds': self._turn.timeout_secs
+        }
+        return message
+
+
+class RandomSequenceTurnTakingGame(FixedSequenceTurnTakingGame):
+
+    nickname = u'random_turns'
+    _rotation = RandomRotation
+
+
+def _descendent_classes(cls):
+    for cls in cls.__subclasses__():
+        yield cls
+        for cls in _descendent_classes(cls):
+            yield cls
+
+
+BY_NAME = {}
+for cls in _descendent_classes(MemoryGame):
+    BY_NAME[cls.__name__] = BY_NAME[cls.nickname] = cls
+
+
+def by_name(name, quorum):
+    """Attempt to return a game class by name.
+
+    Actual class names and known nicknames are both supported.
+    """
+    klass = BY_NAME.get(name)
+    if klass is not None:
+        return klass(quorum)

--- a/memoryexpt2/games.py
+++ b/memoryexpt2/games.py
@@ -134,7 +134,6 @@ class OpenGame(MemoryGame):
 
     @property
     def is_ready(self):
-        logger.info("players: {}, quorum: {}".format(len(self._players), self.quorum))
         return len(self._players) == self.quorum
 
     def tick(self):

--- a/memoryexpt2/static/scripts/experiment.js
+++ b/memoryexpt2/static/scripts/experiment.js
@@ -369,17 +369,16 @@
     $(document).ready(function() {
 
         var egoParticipantId = dallinger.getUrlParameter("participant_id"),
-            socket = startSocket(egoParticipantId);
+            socket = startSocket(egoParticipantId),
+            config = {egoID: egoParticipantId, socket: socket};
 
-        new RecallDisplay({egoID: egoParticipantId, socket: socket});
+        new RecallDisplay(config);
         if (settings.enforceTurns) {
-            new WordSubmissionWithTurns(
-                {egoID: egoParticipantId, socket: socket}
-            );
+            new WordSubmissionWithTurns(config);
         } else {
-            new WordSubmissionFreeForAll({egoID: egoParticipantId, socket: socket})
+            new WordSubmissionFreeForAll(config);
         }
-        new Timer({egoID: egoParticipantId, socket: socket});
+        new Timer(config);
         startPlayer();
     });
 

--- a/memoryexpt2/templates/exp.html
+++ b/memoryexpt2/templates/exp.html
@@ -1,5 +1,13 @@
 {% extends "layout.html" %}
 
+{% block head %}
+<script type="text/javascript">
+    // Parameters
+    settings = {};
+    settings.enforceTurns = {% if experiment.enforce_turns %}true{% else %}false{% endif %};
+</script>
+{% endblock %}
+
 {% block body %}
 <div id="experiment" class="main_div">
     <div id="stimulus">
@@ -65,7 +73,9 @@
         </div>
         <input type="text" id="reproduction" class="form-control" />
         <button id="send-message" type="button" class="btn btn-primary">Send.</button>
+        {% if experiment.enforce_turns %}
         <button id="skip-turn" type="button" class="btn btn-default">Pass</button>
+        {% endif %}
         <button id="leave-chat" type="button" class="btn">I can't recall any more</button>
     </div>
 

--- a/memoryexpt2/topologies.py
+++ b/memoryexpt2/topologies.py
@@ -2,7 +2,7 @@ from dallinger.networks import Empty
 from dallinger.networks import FullyConnected
 
 
-class MemoryExperimentNetwork(object):
+class Topology(object):
     network = Empty
 
     def edges(self):
@@ -12,20 +12,24 @@ class MemoryExperimentNetwork(object):
         return "%s (%s)" % (self.__class__.__name__, self.network)
 
 
-class Collaborative(MemoryExperimentNetwork):
+class Nominal(Topology):
+    all_edges = []
+
+
+class Collaborative(Topology):
     network = FullyConnected
     all_edges = []
 
 
-class Baby2(MemoryExperimentNetwork):
+class Baby2(Topology):
     all_edges = [(0, 1), (0, 2)]
 
 
-class Baby4(MemoryExperimentNetwork):
+class Baby4(Topology):
     all_edges = [(0, 1), (0, 2), (0, 3), (2, 3)]
 
 
-class KarateClub(MemoryExperimentNetwork):
+class KarateClub(Topology):
     """KarateClub network.
 
     Data originally from: http://vlado.fmf.uni-lj.si/pub/networks/data/Ucinet/UciData.htm#zachary
@@ -53,6 +57,27 @@ class KarateClub(MemoryExperimentNetwork):
         (28, 33), (28, 31), (29, 32), (29, 33), (30, 33), (30, 32), (31, 32), (31, 33),
         (32, 33)
     ]
+
+
+class SmallWorld16(Topology):
+    """Small-world network.
+    Manually constructing networks based on getting the edges from
+    running python's NetworkX connected_watts_strogatz_graph(n, k, p) function
+    """
+    all_edges = [
+        (0, 32), (0, 1), (0, 2), (0, 33), (1, 33), (1, 2), (1, 3), (2, 3),
+        (2, 4), (3, 4), (3, 5), (4, 5), (4, 6), (5, 15), (5, 7), (6, 17),
+        (6, 7), (7, 27), (7, 12), (8, 9), (8, 10), (9, 10), (9, 11), (10, 11),
+        (10, 12), (11, 12), (11, 13), (12, 13), (12, 14), (13, 14), (13, 15),
+        (14, 16), (14, 15), (15, 16), (15, 17), (16, 17), (16, 18), (17, 18),
+        (17, 19), (18, 19), (18, 20), (19, 20), (19, 21), (20, 21), (20, 22),
+        (21, 22), (21, 23), (22, 24), (22, 23), (23, 24), (23, 25), (24, 25),
+        (24, 26), (25, 26), (25, 27), (26, 27), (26, 28), (27, 28), (27, 29),
+        (28, 29), (28, 30), (29, 30), (29, 31), (30, 32), (30, 31), (31, 32),
+        (31, 33), (32, 33)
+    ]
+
+
 
 # SMALL-WORLD
 #"""Small-world network.


### PR DESCRIPTION
Only enforce turn-taking for Collaborative/FullyConnected game types.

* In `CoordinatedChatroom.__init__()`, set `self.game` to one of the possible game nicknames (`open`, `random_turns`, `fixed_order_turns`) and the game will proceed with turn-taking or not, and with the appropriate turn order (random vs. consistent sequence).
* `CoordinatedChatroom.topology` still needs to be updated/synchronized so it's matched to the game type (this will be fixed in a future story)
* Ditto for whether to transmit to all neighbors or random neighbors (still required code change to configure, but will be a config.txt setting in the future.
* "Pass" button shown in turn-taking games, but not otherwise