### PR TITLE
Pretty sure we can just use set() to filter valid words

### DIFF
--- a/memoryexpt2/bonuses.py
+++ b/memoryexpt2/bonuses.py
@@ -12,7 +12,7 @@ class Bonus(object):
     """
 
     dollars_per_hour_for_waiting = 5.0
-    dollars_per_word = .005 
+    dollars_per_word = .005
 
     def __init__(self, participant):
         self.participant = participant

--- a/memoryexpt2/static/scripts/experiment.js
+++ b/memoryexpt2/static/scripts/experiment.js
@@ -448,8 +448,13 @@
         }
     }
 
+    function createQuestion(participantId, data) {
+        return dallinger.post("/question/" + participantId, data);
+    }
+
     function showFillerTask() {
-        var filler_answers = [];
+        var participantId = dallinger.getUrlParameter("participant_id"),
+            filler_answers = [];
         $("#stimulus").hide();
         $("#fillertask-form").show();
 
@@ -459,10 +464,14 @@
                 $("#fillertask-form input").each(function( i, item ) {
                     filler_answers.push("{" + item.name + ": " + item.value + "}");
                 });
-                // stores all filler answers in the contents column of info table
-                dallinger.createInfo(
-                    currentNodeId,
-                    {contents: filler_answers.join(", "), info_type: "Fillerans"}
+                // stores all filler answers in the Question table
+                createQuestion(
+                    participantId,
+                    {
+                        question: "Fillerans",
+                        response: filler_answers.join(", "),
+                        number: 0
+                    }
                 ).done(function(resp) {
                     showExperiment();
                 });


### PR DESCRIPTION
@mongates I think what you're looking for to take care of the word list comparison is Python's `Set` class, assuming you don't know about that already. It makes many of these types of problems way simpler: https://docs.python.org/2/library/stdtypes.html#set

In fact, glancing at the docs for `intersection()`, it looks like I didn't even need to convert `words` in `record_word_list()` to a `set`, since `intersection()` "will accept any iterable as an argument". 

I'm pretty sure some of the initial code you had just moved things from a list to a string and then back to a list:
```
(Pdb) words
['onion', 'chicken', 'baby', 'tango']
(Pdb) six.text_type(words)
"['onion', 'chicken', 'baby', 'tango']"
(Pdb) allrecalledwords_at_playerexit =[str(x) for x in allrecalledwords_at_playerexit] #into python list
(Pdb) allrecalledwords_at_playerexit
['onion', 'chicken', 'baby', 'tango']
```

Since `json.dumps()` was used to convert the word list to a string before putting it in the database (last line of `FreeRecallListSource._contents()` method), you can be confident in using `json.loads()` to convert it back to a list.