### PR TITLE
Override is_overrecruited, and tweak some settings to test this in debug mode

### DIFF
--- a/memoryexpt3/experiment.py
+++ b/memoryexpt3/experiment.py
@@ -67,9 +67,9 @@ class CoordinationChatroom(Experiment):
         super(CoordinationChatroom, self).__init__(session)
         config = dlgr.config.get_config()
         self.experiment_repeats = 1
-        self.num_participants = 1 #55 #55 #140 below
+        self.num_participants = 3 #55 #55 #140 below
         self.initial_recruitment_size = self.num_participants #*2 # *3 #note: can't do *2.5 here, won't run even if the end result is an integer
-        self.quorum = self.num_participants  # quorum is read by waiting room
+        self.quorum = 2 #self.num_participants  # quorum is read by waiting room
         self.words_aloud = config.get(u'mexp_words_aloud', False)
         self.topology = topologies.by_name(
             config.get(u'mexp_topology', u'collaborative')
@@ -244,7 +244,21 @@ class CoordinationChatroom(Experiment):
     def create_network(self):
         """Create a new network by reading the configuration file."""
         logger.info("Using the {} network".format(self.topology))
-        return self.topology(max_size=self.num_participants + 1)  # add a Source
+        return self.topology(max_size=self.quorum + 1)  # add a Source
+
+    def is_overrecruited(self, waiting_count):
+        """waiting_count will exclude participants who have returned the HIT,
+        and we don't want to exclude them, because we never want to add a new
+        participant once the experiment has started.
+        """
+        # Default implementation:
+        # if not self.quorum:
+        #     return False
+        # return waiting_count > self.quorum
+
+        # We want to count _everyone_:
+        our_waiting_count = Participant.query.count()
+        return our_waiting_count > self.quorum
 
     def bonus(self, participant):
         """Return a total bonus for a participant.


### PR DESCRIPTION
To test, I set num_participants to 3, with a quorum of 2, so I could join as an "extra" person after the experiment had already started.

The substance of the change is to include participants who have returned the HIT in the total number of participants when determining if a new participant is overrecruited.